### PR TITLE
repair CLI stdout flush issue

### DIFF
--- a/GUI/host/cli.cpp
+++ b/GUI/host/cli.cpp
@@ -9,9 +9,11 @@ int main()
 	_setmode(_fileno(stdout), _O_U16TEXT);
 	_setmode(_fileno(stdin), _O_U16TEXT);
 	wprintf_s(L"Usage: {'attach'|'detach'|hookcode} -Pprocessid\n");
+	fflush(stdout);
 	Host::Start([](auto) {}, [](auto) {}, [](auto) {}, [](auto) {}, [](TextThread* thread, std::wstring& output)
 	{
 		wprintf_s(L"[%I64X:%I32X:%I64X:%I64X:%I64X:%s] %s\n", thread->handle, thread->tp.processId, thread->tp.addr, thread->tp.ctx, thread->tp.ctx2, thread->name.c_str(), output.c_str());
+		fflush(stdout);
 		return false;
 	});
 	wchar_t input[500] = {};


### PR DESCRIPTION
The CLI must call `fflush(stdout)` manually after every line ends, for the pipe does not flush itself automatically as running in terminal, from which every `\n` flushes the output buffer.

see: https://stackoverflow.com/questions/18849112/stream-child-process-output-in-flowing-mode/18849329