### PR TITLE
Feature: show/hide original text

### DIFF
--- a/extensions/extrawindow.cpp
+++ b/extensions/extrawindow.cpp
@@ -3,6 +3,7 @@
 #include <QDialog>
 #include <QInputDialog>
 #include <QColorDialog>
+#include <QMessageBox>
 #include <QMenu>
 #include <QLayout>
 #include <QLabel>
@@ -14,6 +15,7 @@
 extern const char* EXTRA_WINDOW_INFO;
 extern const char* TOPMOST;
 extern const char* SHOW_ORIGINAL;
+extern const char* SHOW_ORIGINAL_INFO;
 extern const char* SIZE_LOCK;
 extern const char* BG_COLOR;
 extern const char* TEXT_COLOR;
@@ -73,7 +75,9 @@ public:
 			setSizeGripEnabled(!lock);
 			settings->setValue(SIZE_LOCK, lock);
 		};
-        auto setShowOriginal = [=](bool showOriginal) {
+        auto setShowOriginal = [=](bool showOriginal)
+		{
+			if (!showOriginal) QMessageBox::information(this, SHOW_ORIGINAL, SHOW_ORIGINAL_INFO);
             settings->setValue(SHOW_ORIGINAL, showOriginal);
         };
 		setGeometry(settings->value(WINDOW, geometry()).toRect());
@@ -165,11 +169,7 @@ bool ProcessSentence(std::wstring& sentence, SentenceInfo sentenceInfo)
 	if (window == nullptr || !sentenceInfo["current select"]) return false;
 
 	QString qSentence = QString::fromStdWString(sentence);
-	if (!window->settings->value(SHOW_ORIGINAL).toBool()) 
-	{
-		int middle = qSentence.count('\n') / 2;
-		qSentence = qSentence.section('\n', middle + 1);
-	};
+	if (!window->settings->value(SHOW_ORIGINAL).toBool()) qSentence = qSentence.section('\n', qSentence.count('\n') / 2 + 1);
 
 	QMetaObject::invokeMethod(window, [=] { window->display->setText(qSentence); });
 	return false;

--- a/text.cpp
+++ b/text.cpp
@@ -109,6 +109,7 @@ const wchar_t* TRANSLATION_ERROR = L"Error while translating";
 const char* EXTRA_WINDOW_INFO = u8R"(Right click to change settings
 Click and drag on window edges to move, or the bottom right corner to resize)";
 const char* TOPMOST = u8"Always on Top";
+const char* SHOW_ORIGINAL = u8"Original Text";
 const char* SIZE_LOCK = u8"Size Locked";
 const char* BG_COLOR = u8"Background Color";
 const char* TEXT_COLOR = u8"Text Color";
@@ -377,6 +378,7 @@ I'm currently looking for a new job: email me if you know anyone hiring US softw
 	EXTRA_WINDOW_INFO = u8R"(Правый клик для изменения настроек
 Нажмите и перетащите за края - для перемещения, или за правый-нижний угол - для изменения размера)";
 	TOPMOST = u8"Поверх всех окон";
+    SHOW_ORIGINAL = u8"Исходный текст";
 	SIZE_LOCK = u8"Фиксированный размер";
 	BG_COLOR = u8"Цвет заднего фона";
 	TEXT_COLOR = u8"Цвет текста";

--- a/text.cpp
+++ b/text.cpp
@@ -191,9 +191,6 @@ Kaynak kodu GKLv3 koruması altında proje ana sayfasında mevcut
 	FUNC_MISSING = u8"Textractor: Fonksiyon mevcut değil";
 	MODULE_MISSING = u8"Textractor: Modül mevcut değil";
 	GARBAGE_MEMORY = u8"Textractor: Hafıza sürekli değişiyor, okumak boşa";
-    SHOW_ORIGINAL = u8"Orjinal metin";
-    SHOW_ORIGINAL_INFO = u8R"(Orijinal metin gösterilmeyecek
-Yalnızca bu uzantı bir çeviri uzantısından sonra doğrudan kullanılırsa çalışır)";
 #endif // TURKISH
 
 #ifdef SPANISH
@@ -255,9 +252,6 @@ Clic y arrastra los bordes de la ventana para moverla, o en la esquina inferior 
 	TEXT_COLOR = u8"Color de texto";
 	FONT_SIZE = u8"Tamaño de letra";
 	TOPMOST = u8"Siempre visible";
-    SHOW_ORIGINAL = u8"Texto original";
-    SHOW_ORIGINAL_INFO = u8R"(El texto original no será mostrado
-Solo funciona si esta extensión se usa directamente después de una extensión de traducción)";
 	REGEX_FILTER = u8"Filtro Regex";
 	INVALID_REGEX = u8"Regex inválido";
 	CURRENT_FILTER = u8"Actualmente filtrando: %1";
@@ -324,9 +318,6 @@ Solo funciona si esta extensión se usa directamente después de una extensión 
 	TEXT_COLOR = u8"文本颜色";
 	FONT_SIZE = u8"字体大小";
 	TOPMOST = u8"总是位于最上层";
-    SHOW_ORIGINAL = u8"原文";
-    SHOW_ORIGINAL_INFO = u8R"(原始文字不会显示
-仅在翻译扩展名后直接使用此扩展名时才有效)";
 	REGEX_FILTER = u8"正则表达式过滤器";
 	INVALID_REGEX = u8"无效的正则表达式";
 	CURRENT_FILTER = u8"当前过滤中: %1";
@@ -498,9 +489,6 @@ Klik dan tarik pinggiran jendela untuk memindahkan, atau sudut kanan bawah untuk
 	TEXT_COLOR = u8"Warna teks";
 	FONT_SIZE = u8"Ukuran teks";
 	TOPMOST = u8"Selalu berada di atas";
-	SHOW_ORIGINAL = u8"Teks asli";
-	SHOW_ORIGINAL_INFO = u8R"(Teks asli tidak akan ditampilkan
-Hanya berfungsi jika ekstensi ini digunakan langsung setelah ekstensi terjemahan)";
 	REGEX_FILTER = u8"Filter regex";
 	INVALID_REGEX = u8"Regex tidak sesuai";
 	CURRENT_FILTER = u8"Regex yang digunakan sekarang: %1";

--- a/text.cpp
+++ b/text.cpp
@@ -110,6 +110,8 @@ const char* EXTRA_WINDOW_INFO = u8R"(Right click to change settings
 Click and drag on window edges to move, or the bottom right corner to resize)";
 const char* TOPMOST = u8"Always on Top";
 const char* SHOW_ORIGINAL = u8"Original Text";
+const char* SHOW_ORIGINAL_INFO = u8R"(Original text will not be shown
+Only works if this extension is used directly after a translation extension)";
 const char* SIZE_LOCK = u8"Size Locked";
 const char* BG_COLOR = u8"Background Color";
 const char* TEXT_COLOR = u8"Text Color";

--- a/text.cpp
+++ b/text.cpp
@@ -191,6 +191,9 @@ Kaynak kodu GKLv3 koruması altında proje ana sayfasında mevcut
 	FUNC_MISSING = u8"Textractor: Fonksiyon mevcut değil";
 	MODULE_MISSING = u8"Textractor: Modül mevcut değil";
 	GARBAGE_MEMORY = u8"Textractor: Hafıza sürekli değişiyor, okumak boşa";
+    SHOW_ORIGINAL = u8"Orjinal metin";
+    SHOW_ORIGINAL_INFO = u8R"(Orijinal metin gösterilmeyecek
+Yalnızca bu uzantı bir çeviri uzantısından sonra doğrudan kullanılırsa çalışır)";
 #endif // TURKISH
 
 #ifdef SPANISH
@@ -252,6 +255,9 @@ Clic y arrastra los bordes de la ventana para moverla, o en la esquina inferior 
 	TEXT_COLOR = u8"Color de texto";
 	FONT_SIZE = u8"Tamaño de letra";
 	TOPMOST = u8"Siempre visible";
+    SHOW_ORIGINAL = u8"Texto original";
+    SHOW_ORIGINAL_INFO = u8R"(El texto original no será mostrado
+Solo funciona si esta extensión se usa directamente después de una extensión de traducción)";
 	REGEX_FILTER = u8"Filtro Regex";
 	INVALID_REGEX = u8"Regex inválido";
 	CURRENT_FILTER = u8"Actualmente filtrando: %1";
@@ -318,6 +324,9 @@ Clic y arrastra los bordes de la ventana para moverla, o en la esquina inferior 
 	TEXT_COLOR = u8"文本颜色";
 	FONT_SIZE = u8"字体大小";
 	TOPMOST = u8"总是位于最上层";
+    SHOW_ORIGINAL = u8"原文";
+    SHOW_ORIGINAL_INFO = u8R"(原始文字不会显示
+仅在翻译扩展名后直接使用此扩展名时才有效)";
 	REGEX_FILTER = u8"正则表达式过滤器";
 	INVALID_REGEX = u8"无效的正则表达式";
 	CURRENT_FILTER = u8"当前过滤中: %1";
@@ -385,6 +394,8 @@ I'm currently looking for a new job: email me if you know anyone hiring US softw
 Нажмите и перетащите за края - для перемещения, или за правый-нижний угол - для изменения размера)";
 	TOPMOST = u8"Поверх всех окон";
     SHOW_ORIGINAL = u8"Исходный текст";
+    SHOW_ORIGINAL_INFO = u8R"(Исходный текст будет скрыт
+Работает только если это расширение используется после расширения перевода)";
 	SIZE_LOCK = u8"Фиксированный размер";
 	BG_COLOR = u8"Цвет заднего фона";
 	TEXT_COLOR = u8"Цвет текста";
@@ -487,6 +498,9 @@ Klik dan tarik pinggiran jendela untuk memindahkan, atau sudut kanan bawah untuk
 	TEXT_COLOR = u8"Warna teks";
 	FONT_SIZE = u8"Ukuran teks";
 	TOPMOST = u8"Selalu berada di atas";
+	SHOW_ORIGINAL = u8"Teks asli";
+	SHOW_ORIGINAL_INFO = u8R"(Teks asli tidak akan ditampilkan
+Hanya berfungsi jika ekstensi ini digunakan langsung setelah ekstensi terjemahan)";
 	REGEX_FILTER = u8"Filter regex";
 	INVALID_REGEX = u8"Regex tidak sesuai";
 	CURRENT_FILTER = u8"Regex yang digunakan sekarang: %1";


### PR DESCRIPTION
Had second feature before to enable/disable multiple lined translations, but decided to discard that (because origin text can be multilined too and it will be a mess), now only one feature included.