### PR TITLE
Add 東京Necro hook

### DIFF
--- a/texthook/engine/engine.cc
+++ b/texthook/engine/engine.cc
@@ -27,7 +27,6 @@
 //#include <boost/foreach.hpp>
 #include <cstdio>
 #include <string>
-#include <sstream>
 
 // jichi 375/2014: Add offset of pusha/pushad
 // http://faydoc.tripod.com/cpu/pushad.htm

--- a/texthook/engine/engine.cc
+++ b/texthook/engine/engine.cc
@@ -26,6 +26,7 @@
 #include "native/pchooks.h"
 //#include <boost/foreach.hpp>
 #include <cstdio>
+#include <sstream>
 #include <string>
 
 // jichi 375/2014: Add offset of pusha/pushad
@@ -6599,29 +6600,6 @@ bool InsertNitroplusHook()
  *  that handles only the text copy is found.
  *
  *  Disassembled code:
- *  TokyoNecro.exe+B53F7 - 51                - push ecx
- *  TokyoNecro.exe+B53F8 - E8 3DC80B00       - call TokyoNecro.exe+171C3A
- *  TokyoNecro.exe+B53FD - 83 C4 04          - add esp,04
- *  TokyoNecro.exe+B5400 - 8B 4D F4          - mov ecx,[ebp-0C]
- *  TokyoNecro.exe+B5403 - 33 C0             - xor eax,eax
- *  TokyoNecro.exe+B5405 - 64 89 0D 00000000 - mov fs:[00000000],ecx
- *  TokyoNecro.exe+B540C - 8B E5             - mov esp,ebp
- *  TokyoNecro.exe+B540E - 5D                - pop ebp
- *  TokyoNecro.exe+B540F - C2 0400           - ret 0004
- *  TokyoNecro.exe+B5412 - CC                - int 3
- *  TokyoNecro.exe+B5413 - CC                - int 3
- *  TokyoNecro.exe+B5414 - CC                - int 3
- *  TokyoNecro.exe+B5415 - CC                - int 3
- *  TokyoNecro.exe+B5416 - CC                - int 3
- *  TokyoNecro.exe+B5417 - CC                - int 3
- *  TokyoNecro.exe+B5418 - CC                - int 3
- *  TokyoNecro.exe+B5419 - CC                - int 3
- *  TokyoNecro.exe+B541A - CC                - int 3
- *  TokyoNecro.exe+B541B - CC                - int 3
- *  TokyoNecro.exe+B541C - CC                - int 3
- *  TokyoNecro.exe+B541D - CC                - int 3
- *  TokyoNecro.exe+B541E - CC                - int 3
- *  TokyoNecro.exe+B541F - CC                - int 3
  *  TokyoNecro.exe+B5420 - 55                - push ebp                  ; place to hook
  *  TokyoNecro.exe+B5421 - 8B EC             - mov ebp,esp
  *  TokyoNecro.exe+B5423 - 6A FF             - push -01
@@ -6638,6 +6616,20 @@ bool InsertNitroplusHook()
  *  TokyoNecro.exe+B5443 - 8B D9             - mov ebx,ecx
  *  TokyoNecro.exe+B5445 - C7 45 EC 0F000000 - mov [ebp-14],0000000F
  *  TokyoNecro.exe+B544C - C7 45 E8 00000000 - mov [ebp-18],00000000
+ *  TokyoNecro.exe+B5453 - C6 45 D8 00       - mov byte ptr [ebp-28],00
+ *  TokyoNecro.exe+B5457 - 8D 70 01          - lea esi,[eax+01]
+ *  TokyoNecro.exe+B545A - 8D 9B 00000000    - lea ebx,[ebx+00000000]
+ *  TokyoNecro.exe+B5460 - 8A 08             - mov cl,[eax]
+ *  TokyoNecro.exe+B5462 - 40                - inc eax
+ *  TokyoNecro.exe+B5463 - 84 C9             - test cl,cl
+ *  TokyoNecro.exe+B5465 - 75 F9             - jne TokyoNecro.exe+B5460
+ *  TokyoNecro.exe+B5467 - 2B C6             - sub eax,esi
+ *  TokyoNecro.exe+B5469 - 52                - push edx
+ *  TokyoNecro.exe+B546A - 8B F8             - mov edi,eax                ▷ Search
+ *  TokyoNecro.exe+B546C - 8D 75 D8          - lea esi,[ebp-28]           |
+ *  TokyoNecro.exe+B546F - E8 6CE1F4FF       - call TokyoNecro.exe+35E0   |
+ *  TokyoNecro.exe+B5474 - C7 45 FC 00000000 - mov [ebp-04],00000000      |
+ *  TokyoNecro.exe+B547B - 8B 8B 84030000    - mov ecx,[ebx+00000384]     ▷
  *
  *  Notes:
  * 
@@ -6662,64 +6654,39 @@ bool InsertNitroplusHook()
 bool InsertTokyoNecroHook() {
 
   const BYTE bytecodes[] = {
-      0x8b, 0x4d, 0xf4,      // 8B 4D F4          - mov ecx,[ebp-0C]   
-      0x33, 0xc0,            // 33 C0             - xor eax,eax
-      0x64, 0x89, 0x0d, XX4, // 64 89 0D 00000000 - mov fs:[00000000],ecx
-      0x8b, 0xe5,            // 8B E5             - mov esp,ebp
-      0x5d,                  // 5D                - pop ebp
-      0xc2, XX2,             // C2 0400           - ret 0004
-      0xcc,                  // CC                - int 3
-      0xcc,                  // CC                - int 3
-      0xcc,                  // CC                - int 3
-      0xcc,                  // CC                - int 3
-      0xcc,                  // CC                - int 3
-      0xcc,                  // CC                - int 3
-      0xcc,                  // CC                - int 3
-      0xcc,                  // CC                - int 3
-      0xcc,                  // CC                - int 3
-      0xcc,                  // CC                - int 3
-      0xcc,                  // CC                - int 3
-      0xcc,                  // CC                - int 3
-      0xcc,                  // CC                - int 3
-      0xcc,                  // CC                - int 3
-      0x55,                  // 55                - push ebp
-      0x8b, 0xec,            // 8B EC             - mov ebp,esp
-      0x6a, 0xff,            // 6A FF             - push -01
-      0x68, XX4,             // 68 E8613000       - push TokyoNecro.exe+1961E8
-      0x64, 0xa1, XX4,       // 64 A1 00000000    - mov eax,fs:[00000000]
-      0x50,                  // 50                - push eax
-      0x64, 0x89, 0x25, XX4, // 64 89 25 00000000 - mov fs:[00000000],esp
-      0x83, 0xec, 0x1c,      // 83 EC 1C          - sub esp,1C
-      0x8b, 0x55, 0x08,      // 8B 55 08          - mov edx,[ebp+08]
-      0x53,                  // 53                - push ebx
-      0x56,                  // 56                - push esi
-      0x8B, 0xc2,            // 8B C2             - mov eax,edx
-      0x57,                  // 57                - push edi
-      0x8b, 0xd9,            // 8B D9             - mov ebx,ecx
-      0xc7, 0x45, 0xec, XX4, // C7 45 EC 0F000000 - mov [ebp-14],0000000F
-      0xc7, 0x45, 0xe8, XX4  // C7 45 E8 00000000 - mov [ebp-18],00000000 // 
+      0x8B, 0xF8,                               // 8B F8             - mov edi,eax
+      0x8D, 0x75, 0xD8,                         // 8D 75 D8          - lea esi,[ebp-28]
+      0xE8, 0x6C, 0xE1, 0xF4, 0xFF,             // E8 6CE1F4FF       - call TokyoNecro.exe+35E0
+      0xC7, 0x45, 0xFC, 0x00, 0x00, 0x00, 0x00, // C7 45 FC 00000000 - mov [ebp-04],00000000
+      0x8B, 0x8B, 0x84, 0x03, 0x00, 0x00        // 8B 8B 84030000    - mov ecx,[ebx+00000384]
   };
   ULONG range = min(processStopAddress - processStartAddress, MAX_REL_ADDR);
   ULONG addr =
       MemDbg::findBytes(bytecodes, sizeof(bytecodes), processStartAddress,
                         processStartAddress + range);
-  enum {
-    addr_offset = 32
-  }; // distance to the beginning of the function
+
+  constexpr ULONG addr_offset = 0xB546A - 0xB5420;  // Distance from memory TokyoNecro.exe+B546A to
+                                                    // TokyoNecro.exe+B5420
 
   if (addr == 0ull) {
     ConsoleOutput("vnreng:TokyoNecro: pattern not found");
     return false;
   }
-  addr += addr_offset;
 
+  addr -= addr_offset;
+  
+  std::stringstream stream;
+  stream << std::hex << addr;
+  std::string debugOut = "vnreng: TokyoNecro. Hook address: " + stream.str();
+  ConsoleOutput(debugOut.c_str());
+  
   enum { push_ebp = 0x55 }; // OPCode for function begin
   if (*(BYTE *)addr != push_ebp) {
-    // This should never happen
-    ConsoleOutput("vnreng:TokyoNecro: beginning of the function not found");
-    return false;
+      // This should never happen
+      ConsoleOutput("vnreng:TokyoNecro: beginning of the function not found");
+      return false;
   }
-
+  
   HookParam hp = {};
   hp.address = addr;
   // The memory address is held at [ebp+08] at TokyoNecro.exe+B543B, meaning that at
@@ -6729,10 +6696,10 @@ bool InsertTokyoNecroHook() {
   // using the data in the registers
   hp.offset = 0x4;
   hp.type = USING_STRING;
-
-  ConsoleOutput("vnreng: INSERT TokyoNecro");
   NewHook(hp, "TokyoNecro");
 
+  ConsoleOutput("vnreng: INSERT TokyoNecro");
+  
   return true;
 }
 

--- a/texthook/engine/engine.cc
+++ b/texthook/engine/engine.cc
@@ -6654,25 +6654,16 @@ bool TextHook() {
       MemDbg::findBytes(bytecodes, sizeof(bytecodes), processStartAddress,
                         processStartAddress + range);
 
-  constexpr ULONG addr_offset = 0xB546A - 0xB5420;  // Distance from memory TokyoNecro.exe+B546A to
-                                                    // TokyoNecro.exe+B5420
-
   if (addr == 0ull) {
     ConsoleOutput("vnreng:TokyoNecro: pattern not found");
     return false;
   }
 
-  addr -= addr_offset;
-
-  constexpr BYTE push_ebp = 0x55; // OPCode for function begin
-  if (*(BYTE *)addr != push_ebp) {
-      // This should never happen
-      ConsoleOutput("vnreng:TokyoNecroText: beginning of the function not found");
-      return false;
-  }
+  // Look for the start of the function
+  const ULONG function_start = MemDbg::findEnclosingAlignedFunction(addr);
   
   HookParam hp = {};
-  hp.address = addr;
+  hp.address = function_start;
   // The memory address is held at [ebp+08] at TokyoNecro.exe+B543B, meaning that at
   // the start of the function it's right above the stack pointer. Since there's no
   // way to do an operation on the value of a register BEFORE dereferencing (e.g.
@@ -6736,25 +6727,16 @@ bool DatabaseHook()
       MemDbg::findBytes(bytecodes, sizeof(bytecodes), processStartAddress,
                         processStartAddress + range);
 
-  constexpr ULONG addr_offset = 0xB53CA - 0xB5380;  // Distance from memory TokyoNecro.exe+B546A to
-                                                    // TokyoNecro.exe+B5420
-
   if (addr == 0ull) {
     ConsoleOutput("vnreng:TokyoNecro: pattern not found");
     return false;
   }
 
-  addr -= addr_offset;
-  
-  constexpr BYTE push_ebp = 0x55; // OPCode for function begin
-  if (*(BYTE *)addr != push_ebp) {
-      // This should never happen
-      ConsoleOutput("vnreng:TokyoNecroDatabase: beginning of the function not found");
-      return false;
-  }
+  // Look for the start of the function
+  const ULONG function_start = MemDbg::findEnclosingAlignedFunction(addr);
   
   HookParam hp = {};
-  hp.address = addr;
+  hp.address = function_start;
   hp.offset = 0x4;
   hp.type = USING_STRING;
   NewHook(hp, "TokyoNecroDatabase");

--- a/texthook/engine/engine.cc
+++ b/texthook/engine/engine.cc
@@ -27,6 +27,7 @@
 //#include <boost/foreach.hpp>
 #include <cstdio>
 #include <string>
+#include <sstream>
 
 // jichi 375/2014: Add offset of pusha/pushad
 // http://faydoc.tripod.com/cpu/pushad.htm
@@ -6582,6 +6583,106 @@ bool InsertNitroplusHook()
   ConsoleOutput("vnreng: INSERT Nitroplus");
   NewHook(hp, "Nitroplus");
   //RegisterEngineType(ENGINE_Nitroplus);
+  return true;
+}
+
+/**
+ *  Jazzinghen 23/05/2020: Add TokyoNecro hook
+ *
+ *  [Nitroplus] 東京Necro 1.01
+ *
+ *  Hook code: HS-14*8@B5420:TokyoNecro.exe
+ * 
+ *  - 
+ *
+ *  Disassembled code:
+ *
+ *  TokyoNecro.exe+B5420 - 55                - push ebp                  ; place to hook
+ *  TokyoNecro.exe+B5421 - 8B EC             - mov ebp,esp
+ *  TokyoNecro.exe+B5423 - 6A FF             - push -01
+ *  TokyoNecro.exe+B5425 - 68 E8613000       - push TokyoNecro.exe+1961E8
+ *  TokyoNecro.exe+B542A - 64 A1 00000000    - mov eax,fs:[00000000]
+ *  TokyoNecro.exe+B5430 - 50                - push eax
+ *  TokyoNecro.exe+B5431 - 64 89 25 00000000 - mov fs:[00000000],esp
+ *  TokyoNecro.exe+B5438 - 83 EC 1C          - sub esp,1C
+ *  TokyoNecro.exe+B543B - 8B 55 08          - mov edx,[ebp+08]
+ *  TokyoNecro.exe+B543E - 53                - push ebx
+ *  TokyoNecro.exe+B543F - 56                - push esi
+ *  TokyoNecro.exe+B5440 - 8B C2             - mov eax,edx
+ *  TokyoNecro.exe+B5442 - 57                - push edi
+ *  TokyoNecro.exe+B5443 - 8B D9             - mov ebx,ecx
+ *  TokyoNecro.exe+B5445 - C7 45 EC 0F000000 - mov [ebp-14],0000000F
+ *  TokyoNecro.exe+B544C - C7 45 E8 00000000 - mov [ebp-18],00000000
+ *
+ *  Notes:
+ *
+ *  The text is contained into the memory location at [ebp+08].
+ *
+ *  There's a second hook that seems to be capturing the game encyclopedia plus
+ *  extra garbage (only when it is brought to screen): /HS4@B5380:tokyonecro.exe
+ *  https://wiki.anime-sharing.com/hgames/index.php?title=AGTH/H-Codes#More_H-Codes.5B74.5D
+ * 
+ *  I can confirm that that function is called consistently at every call of the
+ *  encyclopedia but I don't know what memory location is a positive number in the hook
+ *  code.
+ */
+
+bool InsertTokyoNecroHook() {
+
+  const BYTE bytecodes[] = {
+      0x55,                         // 55                - push ebp
+      0x8b, 0xec,                   // 8B EC             - mov ebp,esp
+      0x6a, 0xff,                   // 6A FF             - push -01
+      0x68, XX4,                    // 68 E8613000       - push TokyoNecro.exe+1961E8
+      0x64, 0xa1, XX4,              // 64 A1 00000000    - mov eax,fs:[00000000]
+      0x50,                         // 50                - push eax
+      0x64, 0x89, 0x25, XX4,        // 64 89 25 00000000 - mov fs:[00000000],esp
+      0x83, 0xec, 0x1c,             // 83 EC 1C          - sub esp,1C
+      0x8b, 0x55, 0x08,             // 8B 55 08          - mov edx,[ebp+08]
+      0x53,                         // 53                - push ebx
+      0x56,                         // 56                - push esi
+      0x8B, 0xc2,                   // 8B C2             - mov eax,edx
+      0x57,                         // 57                - push edi
+      0x8b, 0xd9,                   // 8B D9             - mov ebx,ecx
+      0xc7, 0x45, 0xec, XX4,        // C7 45 EC 0F000000 - mov [ebp-14],0000000F
+      0xc7, 0x45, 0xe8, XX4         // C7 45 E8 00000000 - mov [ebp-18],00000000
+  };
+  ULONG range = min(processStopAddress - processStartAddress, MAX_REL_ADDR);
+  ULONG addr =
+      MemDbg::findBytes(bytecodes, sizeof(bytecodes), processStartAddress,
+                        processStartAddress + range);
+  enum {
+    addr_offset = 0
+  }; // distance to the beginning of the function
+
+  if (addr == 0ull) {
+    ConsoleOutput("vnreng:TokyoNecro: pattern not found");
+    return false;
+  }
+  addr += addr_offset;
+
+  std::stringstream stream;
+  stream << std::hex << addr;
+  std::string debugOut = "vnreng: TokyoNecro. Hook address: " +
+                         stream.str();
+  ConsoleOutput(debugOut.c_str());
+
+  enum { push_ebp = 0x55 }; // OPCode for function begin
+  if (*(BYTE *)addr != push_ebp) {
+    // This should never happen
+    ConsoleOutput("vnreng:TokyoNecro: beginning of the function not found");
+    return false;
+  }
+
+  HookParam hp = {};
+  hp.address = addr;
+  hp.offset = -0x14;
+  hp.index = 8;
+  hp.type = USING_STRING;
+
+  ConsoleOutput("vnreng: INSERT TokyoNecro");
+  NewHook(hp, "TokyoNecro");
+
   return true;
 }
 

--- a/texthook/engine/engine.cc
+++ b/texthook/engine/engine.cc
@@ -6714,12 +6714,6 @@ bool InsertTokyoNecroHook() {
   }
   addr += addr_offset;
 
-  std::stringstream stream;
-  stream << std::hex << addr;
-  std::string debugOut = "vnreng: TokyoNecro. Hook address: " +
-                         stream.str();
-  ConsoleOutput(debugOut.c_str());
-
   enum { push_ebp = 0x55 }; // OPCode for function begin
   if (*(BYTE *)addr != push_ebp) {
     // This should never happen

--- a/texthook/engine/engine.h
+++ b/texthook/engine/engine.h
@@ -125,6 +125,7 @@ bool InsertNeXASHook();         // NeXAS: Thumbnail.pac
 bool InsertNextonHook();        // NEXTON: aInfo.db
 bool InsertNexton1Hook();
 bool InsertNitroplusHook();     // Nitroplus: *.npa
+bool InsertTokyoNecroHook();    // Nitroplus TokyoNecro: *.npk, resource string
 bool InsertPalHook();           // AMUSE CRAFT: *.pac
 bool InsertPensilHook();        // Pensil: PSetup.exe
 bool InsertPONScripterHook();

--- a/texthook/engine/match32.cc
+++ b/texthook/engine/match32.cc
@@ -443,7 +443,6 @@ bool DetermineEngineByFile4()
   // - TokyoNecro.exe in "OriginalFilename"
   if (Util::CheckFile(L"*.npk")) {
     if (Util::SearchResourceString(L"TOKYONECRO")) {
-      ConsoleOutput("vnreng: Hooking TokyoNecro");
       InsertTokyoNecroHook();
     }
     else {

--- a/texthook/engine/match32.cc
+++ b/texthook/engine/match32.cc
@@ -435,6 +435,23 @@ bool DetermineEngineByFile4()
     return true;
   }
 
+  // jichi 11/22/2015: 凍京NECRO 体験版
+  // Jazzinghen 23/05/2020: Add check for 凍京NECRO
+  // ResEdit shows multiple potential strings:
+  // - TOKYONECRO
+  // - 東京NECRO
+  // - TokyoNecro.exe in "OriginalFilename"
+  if (Util::CheckFile(L"*.npk")) {
+    if (Util::SearchResourceString(L"TOKYONECRO")) {
+      ConsoleOutput("vnreng: Hooking TokyoNecro");
+      InsertTokyoNecroHook();
+    }
+    else {
+      ConsoleOutput("vnreng: IGNORE new Nitroplus");
+    }
+    return true;
+  }
+
   return false;
 }
 
@@ -706,12 +723,6 @@ bool DetermineNoEngine()
   // jichi 6/7/2015: RPGMaker v3
   if (Util::CheckFile(L"*.rgss3a")) {
     ConsoleOutput("vnreng: IGNORE RPGMaker RGSS3");
-    return true;
-  }
-
-  // jichi 11/22/2015: 凍京NECRO 体験版
-  if (Util::CheckFile(L"*.npk")) {
-    ConsoleOutput("vnreng: IGNORE new Nitroplus");
     return true;
   }
 


### PR DESCRIPTION
## Tl;dr

Added a 東京Necro hook after finding it using Cheat Engine.

The hook code is the following: `HS-14*8@B5420:TokyoNecro.exe`

## Implementation details

- Modified engine match function to check for `TOKYONECRO` as text resource if Nitroplus package files are found
- Added a hooking function to the engine

## Testing

- Try to hook 東京Necro and all the text should appear

## Additional notes

- There is an additional hook that I found on a wiki that can extract the contents of the Encyclopedia as they are shown on the screen, we could add that as a secondary hook
- The hook also gets the real-time clock that's rendered on the main menu
- The hook doesn't seem to get _the very first_ string after loading a game