### PR TITLE
Extra Window: added Auto Resize and Click Through features

### DIFF
--- a/extensions/extrawindow.cpp
+++ b/extensions/extrawindow.cpp
@@ -329,7 +329,7 @@ private:
 		dictionaryWindow.move(ui.display->mapToGlobal(QPoint(x, y - dictionaryWindow.height())));
 	}
 
-	bool nativeEventFilter(const QByteArray&, void* message, LRESULT* result) override
+	bool nativeEventFilter(const QByteArray&, void* message, long* result) override
 	{
 		auto msg = (MSG*)message;
 		if (msg->message != WM_HOTKEY || msg->wParam != CLICK_THROUGH_HOTKEY) return false;

--- a/extensions/extrawindow.cpp
+++ b/extensions/extrawindow.cpp
@@ -245,7 +245,7 @@ private:
 		if (!autoResizeHeight) return;
 
 		QFontMetrics fontMetrics(ui.display->font(), ui.display);
-		auto boundingRect = fontMetrics.boundingRect(0, 0, width(), INT_MAX, Qt::TextWordWrap, sentence);
+		auto boundingRect = fontMetrics.boundingRect(0, 0, width()-20, INT_MAX, Qt::TextWordWrap, sentence);
 		int newHeight = boundingRect.height() + 30;
 		int currHeight = height();
 

--- a/extensions/extrawindow.ui
+++ b/extensions/extrawindow.ui
@@ -10,6 +10,9 @@
     <height>300</height>
    </rect>
   </property>
+  <property name="contextMenuPolicy">
+    <enum>Qt::CustomContextMenu</enum>
+  </property>
   <layout class="QHBoxLayout">
    <item>
     <widget class="QLabel" name="display">

--- a/text.cpp
+++ b/text.cpp
@@ -179,6 +179,8 @@ const char* SHOW_ORIGINAL = u8"Original text";
 const char* SHOW_ORIGINAL_INFO = u8R"(Original text will not be shown
 Only works if this extension is used directly after a translation extension)";
 const char* SIZE_LOCK = u8"Size lock";
+const char* AUTO_RESIZE_WINDOW_HEIGHT = u8"Auto resize window height";
+const char* CLICK_THROUGH = u8"Click Through";
 const char* OPACITY = u8"Opacity";
 const char* BG_COLOR = u8"Background color";
 const char* TEXT_COLOR = u8"Text color";
@@ -434,6 +436,8 @@ Clic y arrastra los bordes de la ventana para moverla, o en la esquina inferior 
 仅当此扩展置于翻译扩展之后使用时才有效)";
 	OPACITY = u8"透明度";
 	SIZE_LOCK = u8"锁定窗口大小";
+	AUTO_RESIZE_WINDOW_HEIGHT = u8"Auto resize window height";
+	CLICK_THROUGH = u8"Click Through";
 	BG_COLOR = u8"背景颜色";
 	TEXT_COLOR = u8"文本颜色";
 	TEXT_OUTLINE = u8"文字边框";
@@ -623,6 +627,8 @@ Textractor отобразит конечный корневой термин, а
 	SHOW_ORIGINAL_INFO = u8R"(Исходный текст будет скрыт
 Работает только если это расширение используется после расширения перевода)";
 	SIZE_LOCK = u8"Фиксированный размер";
+	AUTO_RESIZE_WINDOW_HEIGHT = u8"Auto resize window height";
+	CLICK_THROUGH = u8"Click Through";
 	OPACITY = u8"Прозрачность";
 	BG_COLOR = u8"Цвет заднего фона";
 	TEXT_COLOR = u8"Цвет текста";
@@ -883,6 +889,8 @@ Questo file deve essere codificato in UTF-8.)";
 	SHOW_ORIGINAL_INFO = u8R"(Testo originale non sarà mostrato
 Funziona solo se questa estenzione è usata direttamente dopo un'estensione di traduzione)";
 	SIZE_LOCK = u8"Lock delle dimensione";
+	AUTO_RESIZE_WINDOW_HEIGHT = u8"Auto resize altezza finestra";
+	CLICK_THROUGH = u8"Clicca attraverso";
 	OPACITY = u8"Opacità";
 	BG_COLOR = u8"Colore dello sfondo";
 	TEXT_COLOR = u8"Colore del testo";
@@ -997,6 +1005,8 @@ Clique e arraste nas beiradas da janela para mover, ou no canto inferior direito
 	SHOW_ORIGINAL_INFO = u8R"(Texto original não será mostrado
 Apenas funciona se essa extensão for usada diretamente após uma extensão de tradução)";
 	SIZE_LOCK = u8"Travar o Tamanho";
+	AUTO_RESIZE_WINDOW_HEIGHT = u8"Auto resize window height";
+	CLICK_THROUGH = u8"Click Through";
 	BG_COLOR = u8"Cor de fundo";
 	TEXT_COLOR = u8"Cor do Texto";
 	FONT = u8"Fonte";
@@ -1072,6 +1082,8 @@ Source code สามารถหาได้จากส่วนของ GPLv
 	TOPMOST = u8"หน้าต่างอยู่บนโปรแกรมอื่น";
 	SHOW_ORIGINAL = u8"ข้อความดังเดิมก่อนแปลภาษา";
 	SIZE_LOCK = u8"ปรับให้ไม่สามารถเปลี่ยนขนาดได้";
+	AUTO_RESIZE_WINDOW_HEIGHT = u8"Auto resize window height";
+	CLICK_THROUGH = u8"Click Through";
 	FONT = u8"ฟ้อนต์";
 #endif // THAI
 
@@ -1137,6 +1149,8 @@ Source code สามารถหาได้จากส่วนของ GPLv
 	SHOW_ORIGINAL_INFO = u8R"(원문이 출력되지 않음
 이 확장기능이 번역확장기능 이후에 사용될때만 동작함)";
 	SIZE_LOCK = u8"사이즈 고정";
+	AUTO_RESIZE_WINDOW_HEIGHT = u8"Auto resize window height";
+	CLICK_THROUGH = u8"Click Through";
 	BG_COLOR = u8"배경색";
 	TEXT_COLOR = u8"글씨색";
 	FONT = u8"폰트";
@@ -1302,6 +1316,8 @@ Ce fichier doit être encodé en UTF-8.)";
 	SHOW_ORIGINAL_INFO = u8R"(Le texte d'origine ne sera pas affiché
 Fonctionne uniquement si cette extension est utilisée directement après une extension de traduction)";
 	SIZE_LOCK = u8"Verouiller la taille";
+	AUTO_RESIZE_WINDOW_HEIGHT = u8"Auto resize window height";
+	CLICK_THROUGH = u8"Click Through";
 	OPACITY = u8"Opacité";
 	BG_COLOR = u8"Couleur d'arrière-plan";
 	TEXT_COLOR = u8"Couleur du texte";

--- a/text.cpp
+++ b/text.cpp
@@ -156,7 +156,6 @@ const char* AUTO_START = u8"Start automatically";
 const wchar_t* ERROR_START_CHROME = L"failed to start Chrome or to connect to it";
 const char* EXTRA_WINDOW_INFO = u8R"(Right click to change settings
 Click and drag on window edges to move, or the bottom right corner to resize)";
-const char* SENTENCE_TOO_BIG = u8"Sentence too large to display";
 const char* MAX_SENTENCE_SIZE = u8"Max sentence size";
 const char* TOPMOST = u8"Always on top";
 const char* DICTIONARY = u8"Dictionary";
@@ -178,21 +177,19 @@ This file must be encoded in UTF-8.)";
 const char* SHOW_ORIGINAL = u8"Original text";
 const char* SHOW_ORIGINAL_INFO = u8R"(Original text will not be shown
 Only works if this extension is used directly after a translation extension)";
-const char* SHOW_ORIGINAL_AFTER_TRANSLATION = u8"Show original text after translation";
+const char* ORIGINAL_AFTER_TRANSLATION = u8"Original text after translation";
 const char* SIZE_LOCK = u8"Size lock";
 const char* POSITION_LOCK = u8"Position lock";
 const char* CENTERED_TEXT = u8"Centered text";
 const char* AUTO_RESIZE_WINDOW_HEIGHT = u8"Auto resize window height";
-const char* CLICK_THROUGH = u8"Click through\tAlt+Shift+T";
-const char* HIDE_TEXT_MOUSEOVER = u8"Hide text mouseover";
-const char* HIDE_TEXT = u8"Hide text\tAlt+Shift+H";
+const char* CLICK_THROUGH = u8"Click through\tShift+X";
+const char* HIDE_MOUSEOVER = u8"Hide while mouse on top";
 const char* OPACITY = u8"Opacity";
 const char* BG_COLOR = u8"Background color";
 const char* TEXT_COLOR = u8"Text color";
 const char* TEXT_OUTLINE = u8"Text outline";
 const char* OUTLINE_COLOR = u8"Outline color";
 const char* OUTLINE_SIZE = u8"Outline size";
-const char* OUTLINE_LAST_SIZE = u8"Last used outline size";
 const char* OUTLINE_SIZE_INFO = u8"Size in pixels (recommended to stay below 20% of the font size)";
 const char* FONT = u8"Font";
 const char* LUA_INTRO = u8R"(--[[
@@ -433,7 +430,6 @@ Clic y arrastra los bordes de la ventana para moverla, o en la esquina inferior 
 	API_KEY = u8"API key";
 	EXTRA_WINDOW_INFO = u8R"(右键修改设置
 在窗口边缘点击并拖拽来移动，或在右下角点击并拖拽来调整大小)";
-	SENTENCE_TOO_BIG = u8"文本过长无法显示";
 	MAX_SENTENCE_SIZE = u8"最大文本长度";
 	TOPMOST = u8"窗口总是置顶";
 	DICTIONARY = u8"字典";
@@ -608,7 +604,6 @@ padding: длина добавочных данных перед строкой 
 	API_KEY = u8"Ключ API";
 	EXTRA_WINDOW_INFO = u8R"(Правый клик для изменения настроек
 Нажмите и перетащите за края - для перемещения, или за правый-нижний угол - для изменения размера)";
-	SENTENCE_TOO_BIG = u8"Предложение слишком длинное для отображения";
 	MAX_SENTENCE_SIZE = u8"Максимальная длина предложения";
 	TOPMOST = u8"Поверх всех окон";
 	DICTIONARY = u8"Словарь";
@@ -867,7 +862,6 @@ esempio: Textractor -p4466 -p"My Game.exe" sta tentando di inniettare i processi
 	API_KEY = u8"Chiave API";
 	EXTRA_WINDOW_INFO = u8R"(Tasto destro per cambiare le impostazioni
 Clicca e trascina i bordi della finestra per muoverla, oppure nell'angolo in basso a destra per ridimensionare)";
-	SENTENCE_TOO_BIG = u8"Sentenza troppo grande da visualizzare";
 	MAX_SENTENCE_SIZE = u8"Dimensione massima sentenza";
 	TOPMOST = u8"Sempre in primo piano";
 	DICTIONARY = u8"Dizionario";
@@ -890,21 +884,19 @@ Questo file deve essere codificato in UTF-8.)";
 	SHOW_ORIGINAL = u8"Testo originale";
 	SHOW_ORIGINAL_INFO = u8R"(Testo originale non sarà mostrato
 Funziona solo se questa estenzione è usata direttamente dopo un'estensione di traduzione)";
-	SHOW_ORIGINAL_AFTER_TRANSLATION = u8"Mostra testo originale dopo traduzione";
+	ORIGINAL_AFTER_TRANSLATION = u8"Mostra testo originale dopo traduzione";
 	SIZE_LOCK = u8"Lock delle dimensione";
 	POSITION_LOCK = u8"Lock delle posizione";
 	CENTERED_TEXT = u8"Testo centrato";
 	AUTO_RESIZE_WINDOW_HEIGHT = u8"Auto resize altezza finestra";
 	CLICK_THROUGH = u8"Clicca attraverso\tAlt+Shift+T";
-	HIDE_TEXT_MOUSEOVER = u8"Nascondi testo mouseover";
-	HIDE_TEXT = u8"Nascondi testo\tAlt+Shift+H";
+	HIDE_MOUSEOVER = u8"Nascondi testo mouseover";
 	OPACITY = u8"Opacità";
 	BG_COLOR = u8"Colore dello sfondo";
 	TEXT_COLOR = u8"Colore del testo";
 	TEXT_OUTLINE = u8"Contorno del testo";
 	OUTLINE_COLOR = u8"Colore del contorno";
 	OUTLINE_SIZE = u8"Dimensione del contorno";
-	OUTLINE_LAST_SIZE = u8"Ultima dimensione del contorno utilizzata";
 	OUTLINE_SIZE_INFO = u8"Dimensione in pixel (consigliato di rimanere sotto il 20% della dimensione del font)";
 	FONT = u8"Font";
 	LUA_INTRO = u8R"(--[[
@@ -1295,7 +1287,6 @@ example: Textractor -p4466 -p"My Game.exe" tries to inject processes with id 446
 	API_KEY = u8"API key";
 	EXTRA_WINDOW_INFO = u8R"(Clic droit pour modifier les paramètres
 Cliquez et faites glisser sur les bords de la fenêtre pour vous déplacer ou dans le coin inférieur droit pour redimensionner)";
-	SENTENCE_TOO_BIG = u8"Phrase trop grande pour être affichée";
 	MAX_SENTENCE_SIZE = u8"Taille maximale de la phrase";
 	TOPMOST = u8"Toujours au dessus";
 	DICTIONARY = u8"Dictionnaire";

--- a/text.cpp
+++ b/text.cpp
@@ -180,7 +180,7 @@ const char* SHOW_ORIGINAL_INFO = u8R"(Original text will not be shown
 Only works if this extension is used directly after a translation extension)";
 const char* SIZE_LOCK = u8"Size lock";
 const char* AUTO_RESIZE_WINDOW_HEIGHT = u8"Auto resize window height";
-const char* CLICK_THROUGH = u8"Click Through";
+const char* CLICK_THROUGH = u8"Click through";
 const char* OPACITY = u8"Opacity";
 const char* BG_COLOR = u8"Background color";
 const char* TEXT_COLOR = u8"Text color";

--- a/text.cpp
+++ b/text.cpp
@@ -178,15 +178,21 @@ This file must be encoded in UTF-8.)";
 const char* SHOW_ORIGINAL = u8"Original text";
 const char* SHOW_ORIGINAL_INFO = u8R"(Original text will not be shown
 Only works if this extension is used directly after a translation extension)";
+const char* SHOW_ORIGINAL_AFTER_TRANSLATION = u8"Show original text after translation";
 const char* SIZE_LOCK = u8"Size lock";
+const char* POSITION_LOCK = u8"Position lock";
+const char* CENTERED_TEXT = u8"Centered text";
 const char* AUTO_RESIZE_WINDOW_HEIGHT = u8"Auto resize window height";
-const char* CLICK_THROUGH = u8"Click through";
+const char* CLICK_THROUGH = u8"Click through\tAlt+Shift+T";
+const char* HIDE_TEXT_MOUSEOVER = u8"Hide text mouseover";
+const char* HIDE_TEXT = u8"Hide text\tAlt+Shift+H";
 const char* OPACITY = u8"Opacity";
 const char* BG_COLOR = u8"Background color";
 const char* TEXT_COLOR = u8"Text color";
 const char* TEXT_OUTLINE = u8"Text outline";
 const char* OUTLINE_COLOR = u8"Outline color";
 const char* OUTLINE_SIZE = u8"Outline size";
+const char* OUTLINE_LAST_SIZE = u8"Last used outline size";
 const char* OUTLINE_SIZE_INFO = u8"Size in pixels (recommended to stay below 20% of the font size)";
 const char* FONT = u8"Font";
 const char* LUA_INTRO = u8R"(--[[
@@ -436,8 +442,6 @@ Clic y arrastra los bordes de la ventana para moverla, o en la esquina inferior 
 仅当此扩展置于翻译扩展之后使用时才有效)";
 	OPACITY = u8"透明度";
 	SIZE_LOCK = u8"锁定窗口大小";
-	AUTO_RESIZE_WINDOW_HEIGHT = u8"Auto resize window height";
-	CLICK_THROUGH = u8"Click Through";
 	BG_COLOR = u8"背景颜色";
 	TEXT_COLOR = u8"文本颜色";
 	TEXT_OUTLINE = u8"文字边框";
@@ -627,8 +631,6 @@ Textractor отобразит конечный корневой термин, а
 	SHOW_ORIGINAL_INFO = u8R"(Исходный текст будет скрыт
 Работает только если это расширение используется после расширения перевода)";
 	SIZE_LOCK = u8"Фиксированный размер";
-	AUTO_RESIZE_WINDOW_HEIGHT = u8"Auto resize window height";
-	CLICK_THROUGH = u8"Click Through";
 	OPACITY = u8"Прозрачность";
 	BG_COLOR = u8"Цвет заднего фона";
 	TEXT_COLOR = u8"Цвет текста";
@@ -888,15 +890,21 @@ Questo file deve essere codificato in UTF-8.)";
 	SHOW_ORIGINAL = u8"Testo originale";
 	SHOW_ORIGINAL_INFO = u8R"(Testo originale non sarà mostrato
 Funziona solo se questa estenzione è usata direttamente dopo un'estensione di traduzione)";
+	SHOW_ORIGINAL_AFTER_TRANSLATION = u8"Mostra testo originale dopo traduzione";
 	SIZE_LOCK = u8"Lock delle dimensione";
+	POSITION_LOCK = u8"Lock delle posizione";
+	CENTERED_TEXT = u8"Testo centrato";
 	AUTO_RESIZE_WINDOW_HEIGHT = u8"Auto resize altezza finestra";
-	CLICK_THROUGH = u8"Clicca attraverso";
+	CLICK_THROUGH = u8"Clicca attraverso\tAlt+Shift+T";
+	HIDE_TEXT_MOUSEOVER = u8"Nascondi testo mouseover";
+	HIDE_TEXT = u8"Nascondi testo\tAlt+Shift+H";
 	OPACITY = u8"Opacità";
 	BG_COLOR = u8"Colore dello sfondo";
 	TEXT_COLOR = u8"Colore del testo";
 	TEXT_OUTLINE = u8"Contorno del testo";
 	OUTLINE_COLOR = u8"Colore del contorno";
 	OUTLINE_SIZE = u8"Dimensione del contorno";
+	OUTLINE_LAST_SIZE = u8"Ultima dimensione del contorno utilizzata";
 	OUTLINE_SIZE_INFO = u8"Dimensione in pixel (consigliato di rimanere sotto il 20% della dimensione del font)";
 	FONT = u8"Font";
 	LUA_INTRO = u8R"(--[[
@@ -1005,8 +1013,6 @@ Clique e arraste nas beiradas da janela para mover, ou no canto inferior direito
 	SHOW_ORIGINAL_INFO = u8R"(Texto original não será mostrado
 Apenas funciona se essa extensão for usada diretamente após uma extensão de tradução)";
 	SIZE_LOCK = u8"Travar o Tamanho";
-	AUTO_RESIZE_WINDOW_HEIGHT = u8"Auto resize window height";
-	CLICK_THROUGH = u8"Click Through";
 	BG_COLOR = u8"Cor de fundo";
 	TEXT_COLOR = u8"Cor do Texto";
 	FONT = u8"Fonte";
@@ -1082,8 +1088,6 @@ Source code สามารถหาได้จากส่วนของ GPLv
 	TOPMOST = u8"หน้าต่างอยู่บนโปรแกรมอื่น";
 	SHOW_ORIGINAL = u8"ข้อความดังเดิมก่อนแปลภาษา";
 	SIZE_LOCK = u8"ปรับให้ไม่สามารถเปลี่ยนขนาดได้";
-	AUTO_RESIZE_WINDOW_HEIGHT = u8"Auto resize window height";
-	CLICK_THROUGH = u8"Click Through";
 	FONT = u8"ฟ้อนต์";
 #endif // THAI
 
@@ -1149,8 +1153,6 @@ Source code สามารถหาได้จากส่วนของ GPLv
 	SHOW_ORIGINAL_INFO = u8R"(원문이 출력되지 않음
 이 확장기능이 번역확장기능 이후에 사용될때만 동작함)";
 	SIZE_LOCK = u8"사이즈 고정";
-	AUTO_RESIZE_WINDOW_HEIGHT = u8"Auto resize window height";
-	CLICK_THROUGH = u8"Click Through";
 	BG_COLOR = u8"배경색";
 	TEXT_COLOR = u8"글씨색";
 	FONT = u8"폰트";
@@ -1316,8 +1318,6 @@ Ce fichier doit être encodé en UTF-8.)";
 	SHOW_ORIGINAL_INFO = u8R"(Le texte d'origine ne sera pas affiché
 Fonctionne uniquement si cette extension est utilisée directement après une extension de traduction)";
 	SIZE_LOCK = u8"Verouiller la taille";
-	AUTO_RESIZE_WINDOW_HEIGHT = u8"Auto resize window height";
-	CLICK_THROUGH = u8"Click Through";
 	OPACITY = u8"Opacité";
 	BG_COLOR = u8"Couleur d'arrière-plan";
 	TEXT_COLOR = u8"Couleur du texte";


### PR DESCRIPTION
Added the auto resize window height and click through mode.

The width should remain unchanged and can only be changed with the mouse, while the height adjusts to the exact number of lines of the displayed text.

In the right click menu there are the two items "Auto resize windows height" and "Click Through".
The state of the AutoResize selection is stored in the Textractor.ini file.

Added shortcut CTRL+SHIFT+T to switch the "Click Through" status.
If "Click Through" is active and you want to deactivate it, you have to give focus to the main textractor window and then press CTRL+SHIFT+T and the ExtraWindow becomes clickable again.
