### PR TITLE
DevTools DeepL Translate temporary fix

### DIFF
--- a/extensions/devtoolsdeepltranslate.cpp
+++ b/extensions/devtoolsdeepltranslate.cpp
@@ -133,7 +133,7 @@ std::pair<bool, std::wstring> Translate(const std::wstring& text)
 	// DevTools can't handle concurrent translations yet
 	static std::mutex translationMutex;
 	std::scoped_lock lock(translationMutex);
-	DevTools::SendRequest("Page.navigate", FormatString(LR"({"url":"https://www.deepl.com/en/translator#any/%s/%s"})", translateTo.Copy(), Escape(text)));
+	DevTools::SendRequest("Page.navigate", FormatString(LR"({"url":"https://www.deepl.com/en/translator#%s/%s/%s"})", translateFrom.Copy(), translateTo.Copy(), Escape(text)));
 
 	if (translateFrom.Copy() != autoDetectLanguage)
 		DevTools::SendRequest("Runtime.evaluate", FormatString(LR"({"expression":"


### PR DESCRIPTION
Temporary fix for "DevTools DeepL Translate" to make the extension usable, but doesn't completely fix it.

Change "any" to "translateFrom.Copy()" in the call URL, but the selector for forcing the language from the menu no longer works.
