### PR TITLE
devtools: fixed failure to remove devtoolscache when closing the program

### DIFF
--- a/extensions/devtools.cpp
+++ b/extensions/devtools.cpp
@@ -87,7 +87,10 @@ namespace DevTools
 			CloseHandle(processInfo.hProcess);
 			CloseHandle(processInfo.hThread);
 		}
-		try { std::filesystem::remove_all(L"devtoolscache"); } catch (std::filesystem::filesystem_error) {}
+		for (int retry = 0; ++retry < 20; Sleep(100)) {
+			try { std::filesystem::remove_all(L"devtoolscache"); break; }
+			catch (std::filesystem::filesystem_error) { continue; }
+		} 
 		OnStatusChanged("Stopped");
 	}
 


### PR DESCRIPTION
Added retry loop removing devtoolscache folder on failure.