### PR TITLE
CLI: fix scanf pattern

### DIFF
--- a/GUI/host/cli.cpp
+++ b/GUI/host/cli.cpp
@@ -30,7 +30,7 @@ int main()
 	{
 		wchar_t command[500] = {};
 		DWORD processId = 0;
-		if (swscanf(input, L"%500s -P%d", command, &processId) != 2) ExitProcess(0);
+		if (swscanf(input, L"%500ls -P%d", command, &processId) != 2) ExitProcess(0);
 		if (_wcsicmp(command, L"attach") == 0) Host::InjectProcess(processId);
 		else if (_wcsicmp(command, L"detach") == 0) Host::DetachProcess(processId);
 		else if (auto hp = HookCode::Parse(command)) Host::InsertHook(processId, hp.value());


### PR DESCRIPTION
According to https://en.cppreference.com/w/c/io/fwscanf

You must use `%ls` to match `wchar_t*`

Though I didn't test it, because I don't have VC and qt installed, nor do I know CMake.

Well, it seems that for MSVC `%s` is OK. But I think it's better to comply with the standard.