### PR TITLE
fix rateLimitTimespan issue #665

### DIFF
--- a/extensions/translatewrapper.cpp
+++ b/extensions/translatewrapper.cpp
@@ -166,7 +166,8 @@ bool ProcessSentence(std::wstring& sentence, SentenceInfo sentenceInfo)
 				tokens.push(token); // popped one too many
 				break;
 			}
-			tokens.push(current);
+			if (tokens.size() < tokenCount) tokens.push(current);
+			else return false;
 			return tokens.size() <= tokenCount;
 		}
 

--- a/extensions/translatewrapper.cpp
+++ b/extensions/translatewrapper.cpp
@@ -166,9 +166,9 @@ bool ProcessSentence(std::wstring& sentence, SentenceInfo sentenceInfo)
 				tokens.push(token); // popped one too many
 				break;
 			}
-			if (tokens.size() < tokenCount) tokens.push(current);
-			else return false;
-			return tokens.size() <= tokenCount;
+			bool available = tokens.size() < tokenCount;
+			if (available) tokens.push(current);
+			return available;
 		}
 
 	private:


### PR DESCRIPTION
Fixed issue reported in thread #665
...It appears that any actions or attempts of translating anything after the 'max translation requests in timespan' threshold is reached, when we get the rate limit has been reached error, are treated as if they were valid translation requests, meaning that we need to wait the same amount of time set in the timespan field starting from the moment when we got the error and not when Textractor last successfully requested a translation.