### PR TITLE
Replacer Process Hooked Extension

### DIFF
--- a/deploy.ps1
+++ b/deploy.ps1
@@ -57,6 +57,7 @@ foreach ($language in @{
 			"Remove Repeated Phrases 2",
 			"Remove 30 Repeated Sentences",
 			"Replacer",
+			"Replacer Process Hooked",
 			"Styler",
 			"Thread Linker"
 		))

--- a/extensions/CMakeLists.txt
+++ b/extensions/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(Remove\ Repeated\ Phrases MODULE removerepeatphrase.cpp extensionimp
 add_library(Remove\ Repeated\ Phrases\ 2 MODULE removerepeatphrase2.cpp extensionimpl.cpp)
 add_library(Remove\ 30\ Repeated\ Sentences MODULE removerepeatsentence.cpp extensionimpl.cpp)
 add_library(Replacer MODULE replacer.cpp extensionimpl.cpp)
+add_library(Replacer\ Process\ Hooked MODULE replacerprocesshooked.cpp extensionimpl.cpp)
 add_library(Styler MODULE styler.cpp extensionimpl.cpp)
 add_library(Thread\ Linker MODULE threadlinker.cpp extensionimpl.cpp)
 
@@ -38,6 +39,7 @@ target_precompile_headers(Remove\ Repeated\ Phrases REUSE_FROM pch)
 target_precompile_headers(Remove\ Repeated\ Phrases\ 2 REUSE_FROM pch)
 target_precompile_headers(Remove\ 30\ Repeated\ Sentences REUSE_FROM pch)
 target_precompile_headers(Replacer REUSE_FROM pch)
+target_precompile_headers(Replacer\ Process\ Hooked REUSE_FROM pch)
 target_precompile_headers(Styler REUSE_FROM pch)
 target_precompile_headers(Thread\ Linker REUSE_FROM pch)
 

--- a/extensions/replacerprocesshooked.cpp
+++ b/extensions/replacerprocesshooked.cpp
@@ -1,0 +1,134 @@
+﻿#include "extension.h"
+#include "blockmarkup.h"
+#include <cwctype>
+#include <fstream>
+#include <sstream>
+#include <process.h>
+#include "module.h"
+
+extern const wchar_t* REPLACER_INSTRUCTIONS;
+
+std::wstring  replaceSaveFile;
+std::wstring  currProcessName;
+
+std::atomic<std::filesystem::file_time_type> replaceFileLastWrite = {};
+concurrency::reader_writer_lock m;
+
+class Trie
+{
+public:
+	Trie(const std::istream& replacementScript)
+	{
+		BlockMarkupIterator replacementScriptParser(replacementScript, Array<std::wstring_view>{ L"|ORIG|", L"|BECOMES|" });
+		while (auto read = replacementScriptParser.Next())
+		{
+			const auto& [original, replacement] = read.value();
+			Node* current = &root;
+			for (auto ch : original) if (!Ignore(ch)) current = Next(current, ch);
+			if (current != &root)
+				current->value = charStorage.insert(charStorage.end(), replacement.c_str(), replacement.c_str() + replacement.size() + 1) - charStorage.begin();
+		}
+	}
+
+	std::wstring Replace(const std::wstring& sentence) const
+	{
+		std::wstring result;
+		for (int i = 0; i < sentence.size();)
+		{
+			std::wstring_view replacement(sentence.c_str() + i, 1);
+			int originalLength = 1;
+
+			const Node* current = &root;
+			for (int j = i; current && j <= sentence.size(); ++j)
+			{
+				if (current->value >= 0)
+				{
+					replacement = charStorage.data() + current->value;
+					originalLength = j - i;
+				}
+				if (!Ignore(sentence[j])) current = Next(current, sentence[j]) ? Next(current, sentence[j]) : Next(current, L'^');
+			}
+
+			result += replacement;
+			i += originalLength;
+		}
+		return result;
+	}
+
+	bool Empty()
+	{
+		return root.charMap.empty();
+	}
+
+private:
+	static bool Ignore(wchar_t ch)
+	{
+		return ch <= 0x20 || iswspace(ch);
+	}
+
+	template <typename Node>
+	static Node* Next(Node* node, wchar_t ch)
+	{
+		auto it = std::lower_bound(node->charMap.begin(), node->charMap.end(), ch, [](const auto& one, auto two) { return one.first < two; });
+		if (it != node->charMap.end() && it->first == ch) return it->second.get();
+		if constexpr (!std::is_const_v<Node>) return node->charMap.insert(it, { ch, std::make_unique<Node>() })->second.get();
+		return nullptr;
+	}
+
+	struct Node
+	{
+		std::vector<std::pair<wchar_t, std::unique_ptr<Node>>> charMap;
+		ptrdiff_t value = -1;
+	} root;
+
+	std::vector<wchar_t> charStorage;
+} trie = { std::istringstream("") };
+
+void UpdateReplacements()
+{
+	try
+	{
+		if (replaceFileLastWrite.exchange(std::filesystem::last_write_time(replaceSaveFile)) == std::filesystem::last_write_time(replaceSaveFile)) return;
+		std::scoped_lock lock(m);
+		trie = Trie(std::ifstream(replaceSaveFile, std::ios::binary));
+	}
+	catch (std::filesystem::filesystem_error) { replaceFileLastWrite.store({}); }
+}
+
+void InitializeReplacements()
+{
+	UpdateReplacements();
+	if (trie.Empty())
+	{
+		auto file = std::ofstream(replaceSaveFile, std::ios::binary) << "\xff\xfe";
+		for (auto ch : std::wstring_view(REPLACER_INSTRUCTIONS))
+			file << (ch == L'\n' ? std::string_view("\r\0\n", 4) : std::string_view((char*)&ch, 2));
+		// I couldn't get it to work. Commented
+		//_spawnlp(_P_DETACH, "notepad", "notepad", replaceSaveFile, NULL); // show file to user
+	}
+}
+
+bool ProcessSentence(std::wstring& sentence, SentenceInfo sentenceInfo)
+{
+	if (!sentenceInfo["current select"] || sentenceInfo["text number"] == 0) return false;
+
+	if (auto processName = GetModuleFilename(sentenceInfo["process id"]))
+	{
+		if (currProcessName == processName.value())
+			UpdateReplacements();
+		else 
+		{
+			currProcessName = processName.value();
+			// SavedReplacements_<directory name containing hocked process>.txt
+			replaceSaveFile = FormatString(L"SavedReplacements_%ls.txt", FormatString(L"%ls", std::filesystem::path(currProcessName).parent_path().filename().c_str()));
+			InitializeReplacements();
+		}
+	}
+	else 
+		return false;
+
+	concurrency::reader_writer_lock::scoped_lock_read readLock(m);
+	sentence = trie.Replace(sentence);
+	return true;
+}
+

--- a/extensions/replacerprocesshooked.cpp
+++ b/extensions/replacerprocesshooked.cpp
@@ -60,6 +60,11 @@ public:
 		return root.charMap.empty();
 	}
 
+	void Clear()
+	{
+		root.charMap.clear();
+	}
+
 private:
 	static bool Ignore(wchar_t ch)
 	{
@@ -97,6 +102,7 @@ void UpdateReplacements()
 
 void InitializeReplacements()
 {
+	trie.Clear();
 	UpdateReplacements();
 	if (trie.Empty())
 	{


### PR DESCRIPTION
Extension derived from the "Replacer" extension.
Open a different replacement file depending on the hooked process.
Upon receiving text for the first time from a hooked process, it creates a file named like this:
SavedReplacements_\<directory name containing hocked process\>.txt
The file has the same structure as that of the "Replacer" extension.