### PR TITLE
Translator extensions use a different cache file depending on the hooked process

### DIFF
--- a/extensions/translatewrapper.cpp
+++ b/extensions/translatewrapper.cpp
@@ -35,15 +35,21 @@ Settings settings;
 std::wstring  repositoryDir = L".";
 std::wstring  currProcessName;
 
+std::wstring  s2ws(const std::string &s)
+{
+	std::wstring wsTmp(s.begin(), s.end());
+	return wsTmp;
+}
+
 namespace
 {
 	Synchronized<TranslationParam> tlp;
 	Synchronized<std::unordered_map<std::wstring, std::wstring>> translationCache;
 	int savedSize = 0;
 
-	std::string CacheFile()
+	std::wstring CacheFile()
 	{
-		return FormatString("%ls/%s Cache (%S).txt", repositoryDir, TRANSLATION_PROVIDER, tlp->translateTo);
+		return FormatString(L"%ls/%s Cache (%lS).txt", repositoryDir, s2ws(FormatString("%s", TRANSLATION_PROVIDER)), tlp->translateTo);
 	}
 	void SaveCache()
 	{

--- a/text.cpp
+++ b/text.cpp
@@ -19,6 +19,7 @@
 
 // If you are updating a previous translation see https://github.com/Artikash/Textractor/issues/313
 
+const wchar_t* REPOSITORY = L"repository/";
 const char* NATIVE_LANGUAGE = "English";
 const char* ATTACH = u8"Attach to game";
 const char* LAUNCH = u8"Launch game";


### PR DESCRIPTION
In the Textrator folder a sub-folder is created with the name "repository" and inside this, after having received the text for the first time from a hooked process, a folder is created with the name of the VN folder.
Translation cache file is created inside this folder.
If no process is hooked and the translator is used (for example using the cliboard window) the cache file is generated outside the repository folder.