### PR TITLE
Ignore clipboard text present at startup

### DIFF
--- a/GUI/host/host.cpp
+++ b/GUI/host/host.cpp
@@ -170,6 +170,9 @@ namespace Host
 			if (statusCode == HC_ACTION && wParam == PM_REMOVE && ((MSG*)lParam)->message == WM_CLIPBOARDUPDATE) SetEvent(clipboardUpdate);
 			return CallNextHookEx(NULL, statusCode, wParam, lParam);
 		}, NULL, GetCurrentThreadId());
+
+		WaitForSingleObject(clipboardUpdate, INFINITE); // Ignore clipboard text present at startup
+
 		std::thread([]
 		{
 			while (WaitForSingleObject(clipboardUpdate, INFINITE) == WAIT_OBJECT_0)


### PR DESCRIPTION
If some text is in the clipboard at the start of the program it is discarded.
It may happen that you don't remember having previously copied sensitive text to the clipboard (I have a bad habit of copying passwords to the clipboard).