### PR TITLE
Devtools extensions: Fix DeepL error in hidden mode/chrome user data cache error if there are spaces in path

### DIFF
--- a/extensions/devtools.cpp
+++ b/extensions/devtools.cpp
@@ -36,11 +36,11 @@ namespace
 		if (process) DevTools::Close();
 
 		auto args = FormatString(
-			L"%s --proxy-server=direct:// --disable-extensions --disable-gpu --user-data-dir=\"%s\\devtoolscache\" --remote-debugging-port=9222",
+			L"%s --proxy-server=direct:// --disable-extensions --disable-gpu --no-first-run --user-data-dir=\"%s\\devtoolscache\" --remote-debugging-port=9222",
 			chromePath,
 			std::filesystem::current_path().wstring()
 		);
-		if (headless) args += L" --headless";
+		args += headless ? L" --window-size=1920,1080 --headless" : L" --window-size=850,900";
 		DWORD exitCode = 0;
 		STARTUPINFOW DUMMY = { sizeof(DUMMY) };
 		PROCESS_INFORMATION processInfo = {};

--- a/extensions/devtools.cpp
+++ b/extensions/devtools.cpp
@@ -36,7 +36,7 @@ namespace
 		if (process) DevTools::Close();
 
 		auto args = FormatString(
-			L"%s --proxy-server=direct:// --disable-extensions --disable-gpu --user-data-dir=%s\\devtoolscache --remote-debugging-port=9222",
+			L"%s --proxy-server=direct:// --disable-extensions --disable-gpu --user-data-dir=\"%s\\devtoolscache\" --remote-debugging-port=9222",
 			chromePath,
 			std::filesystem::current_path().wstring()
 		);


### PR DESCRIPTION
Fixed bug where devtools extensions fail to create chrome user data cache if there are spaces in the path.