### PR TITLE
translatewrapper: regex lineedit doesn't translate sentence on a full match

### DIFF
--- a/extensions/bingtranslate.cpp
+++ b/extensions/bingtranslate.cpp
@@ -194,6 +194,7 @@ extern const std::unordered_map<std::wstring, std::wstring> codes
 
 bool translateSelectedOnly = false, useRateLimiter = true, rateLimitSelected = false, useCache = true, useFilter = true;
 int tokenCount = 30, rateLimitTimespan = 60000, maxSentenceSize = 1000;
+std::wstring dontTranslateIfMatch = L"";
 
 std::pair<bool, std::wstring> Translate(const std::wstring& text, TranslationParam tlp)
 {

--- a/extensions/deepltranslate.cpp
+++ b/extensions/deepltranslate.cpp
@@ -99,6 +99,7 @@ extern const std::unordered_map<std::wstring, std::wstring> codes
 
 bool translateSelectedOnly = true, useRateLimiter = true, rateLimitSelected = true, useCache = true, useFilter = true;
 int tokenCount = 10, rateLimitTimespan = 60000, maxSentenceSize = 1000;
+std::wstring dontTranslateIfMatch = L"";
 
 enum KeyType { CAT, REST };
 int keyType = REST;

--- a/extensions/devtoolsdeepltranslate.cpp
+++ b/extensions/devtoolsdeepltranslate.cpp
@@ -99,6 +99,7 @@ extern const std::unordered_map<std::wstring, std::wstring> codes
 
 bool translateSelectedOnly = true, useRateLimiter = true, rateLimitSelected = false, useCache = true, useFilter = true;
 int tokenCount = 30, rateLimitTimespan = 60000, maxSentenceSize = 2500;
+std::wstring dontTranslateIfMatch = L"";
 
 BOOL WINAPI DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
 {

--- a/extensions/devtoolspapagotranslate.cpp
+++ b/extensions/devtoolspapagotranslate.cpp
@@ -48,6 +48,7 @@ extern const std::unordered_map<std::wstring, std::wstring> codes
 
 bool translateSelectedOnly = true, useRateLimiter = true, rateLimitSelected = false, useCache = true, useFilter = true;
 int tokenCount = 30, rateLimitTimespan = 60000, maxSentenceSize = 2500;
+std::wstring dontTranslateIfMatch = L"";
 
 BOOL WINAPI DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
 {

--- a/extensions/devtoolssystrantranslate.cpp
+++ b/extensions/devtoolssystrantranslate.cpp
@@ -114,6 +114,7 @@ extern const std::unordered_map<std::wstring, std::wstring> codes
 
 bool translateSelectedOnly = true, useRateLimiter = true, rateLimitSelected = false, useCache = true, useFilter = true;
 int tokenCount = 30, rateLimitTimespan = 60000, maxSentenceSize = 2500;
+std::wstring dontTranslateIfMatch = L"";
 
 BOOL WINAPI DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
 {

--- a/extensions/googletranslate.cpp
+++ b/extensions/googletranslate.cpp
@@ -234,6 +234,7 @@ extern const std::unordered_map<std::wstring, std::wstring> codes
 
 bool translateSelectedOnly = false, useRateLimiter = true, rateLimitSelected = false, useCache = true, useFilter = true;
 int tokenCount = 30, rateLimitTimespan = 60000, maxSentenceSize = 1000;
+std::wstring dontTranslateIfMatch = L"";
 
 std::pair<bool, std::wstring> Translate(const std::wstring& text, TranslationParam tlp)
 {

--- a/text.cpp
+++ b/text.cpp
@@ -157,6 +157,7 @@ const wchar_t* ERROR_START_CHROME = L"failed to start Chrome or to connect to it
 const char* EXTRA_WINDOW_INFO = u8R"(Right click to change settings
 Click and drag on window edges to move, or the bottom right corner to resize)";
 const char* MAX_SENTENCE_SIZE = u8"Max sentence size";
+const char* DONT_TRANSLATE_IF_MATCH = u8"Don't translate if match full";
 const char* TOPMOST = u8"Always on top";
 const char* DICTIONARY = u8"Dictionary";
 const char* DICTIONARY_INSTRUCTIONS = u8R"(This file is used only for the "Dictionary" feature of the Extra Window extension.
@@ -875,6 +876,7 @@ esempio: Textractor -p4466 -p"My Game.exe" sta tentando di inniettare i processi
 	EXTRA_WINDOW_INFO = u8R"(Tasto destro per cambiare le impostazioni
 Clicca e trascina i bordi della finestra per muoverla, oppure nell'angolo in basso a destra per ridimensionare)";
 	MAX_SENTENCE_SIZE = u8"Dimensione massima sentenza";
+	DONT_TRANSLATE_IF_MATCH = u8"Non traduce se corrisponde completamente";
 	TOPMOST = u8"Sempre in primo piano";
 	DICTIONARY = u8"Dizionario";
 	DICTIONARY_INSTRUCTIONS = u8R"(Questo file è utilizzato solo per la funzione "Dizionario" dell'estenzione Extra Window.


### PR DESCRIPTION
Added lineedit to tranlsator extensions with regex filter that doesn't send the sentence to the translator on a full match, but displays the text in the extra window.
In this way you can create rules not to send untranslatable text to the translator.

Examples:
1 - For the Japanese source language. This rule does not send the sentence to the translator if at least one Japanese character is not present. (Rule copied from VN OCR. Thanks @leminhyen2)
`[\u0000-\u303f\u3100-\u33ff\u4dc0-\u4dff\ua000-\uf8ff\ufb00-\uff65\uffa0-\uffff]+`

2 - For source language English, Italian and other Western languages. If the sentence doesn't contain at least one character of the alphabet (a-z), it does not send the sentence to the translator.
`[^a-zA-Z]+`
