### PR TITLE
Improve performance of Mono hook searching on x64

### DIFF
--- a/cmake/QtUtils.cmake
+++ b/cmake/QtUtils.cmake
@@ -1,8 +1,8 @@
 macro(msvc_registry_search)
-	if(NOT DEFINED Qt5_DIR)
+	if(NOT DEFINED Qt5_DIR OR "${Qt5_DIR}" STREQUAL "Qt5_DIR-NOTFOUND")
 		# look for user-registry pointing to qtcreator
 		get_filename_component(QT_BIN [HKEY_CURRENT_USER\\Software\\Classes\\Applications\\QtProject.QtCreator.pro\\shell\\Open\\Command] PATH)
-
+		
 		# get root path so we can search for 5.3, 5.4, 5.5, etc
 		string(REPLACE "/Tools" ";" QT_BIN "${QT_BIN}")
 		list(GET QT_BIN 0 QT_BIN)

--- a/texthook/engine/mono/monoobject.h
+++ b/texthook/engine/mono/monoobject.h
@@ -33,6 +33,9 @@ struct MonoString;
 struct MonoThreadsSync;
 struct MonoThread;
 struct MonoVTable;
+struct MonoImage;
+struct MonoClass;
+struct MonoMethod;
 
 struct MonoObject {
   MonoVTable *vtable;


### PR DESCRIPTION
In at least 2 games (gnosia/ai somnium files) that I have tried to hook, the mono scanning causes a massive hang (30+ seconds of not responding). With this approach no lag is detected with configured games. 

