### PR TITLE
Force detach process on exit

### DIFF
--- a/GUI/mainwindow.cpp
+++ b/GUI/mainwindow.cpp
@@ -689,6 +689,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent)
 
 MainWindow::~MainWindow()
 {
+	DetachProcess(); //force detach process
 	Settings().setValue(WINDOW, geometry());
 	CleanupExtensions();
 	SetErrorMode(SEM_NOGPFAULTERRORBOX);


### PR DESCRIPTION
In some cases, if you don't detach processes before closing Textractor, the VN crashes on exit.
One case is the new Unityx86 Mono hook method added by DDWSdwqdq (PR #834) which uses the assembly_foreach approach.
This change forces a detach process when Textractor exits
However, Textractor must be closed before the VN