### PR TITLE
Restored headless mode in Devtools extensions

### DIFF
--- a/extensions/devtools.cpp
+++ b/extensions/devtools.cpp
@@ -40,7 +40,7 @@ namespace
 			chromePath,
 			std::filesystem::current_path().wstring()
 		);
-		args += headless ? L" --window-size=1920,1080 --headless" : L" --window-size=850,900";
+		args += headless ? L" --window-size=1920,1080 --headless=new" : L" --window-size=850,900";
 		DWORD exitCode = 0;
 		STARTUPINFOW DUMMY = { sizeof(DUMMY) };
 		PROCESS_INFORMATION processInfo = {};


### PR DESCRIPTION
I updated my computer and discovered that with win10 and win11 with the updated version of the Chrome browser the "Hide Chrome window" option no longer worked.
(This fix moves the problem to win7)